### PR TITLE
topic-tdk*: switch to xorg modesetting driver

### DIFF
--- a/recipes-graphics/packagegroups/packagegroup-core-x11-xserver.bbappend
+++ b/recipes-graphics/packagegroups/packagegroup-core-x11-xserver.bbappend
@@ -1,0 +1,3 @@
+XSERVER_ADDITIONAL ?= " xf86-video-modesetting"
+XSERVER_append_topic-miamimp = "${XSERVER_ADDITIONAL}"
+XSERVER_append_topic-miami = "${XSERVER_ADDITIONAL}"

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/topic-miami/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/topic-miami/xorg.conf
@@ -4,5 +4,5 @@ Section "Device"
   Option "AccelMethod" "none"
 
   # Disable HW cursor since it makes the cursor blink at movement
-  Option "SWcursor" "on"
+  Option "SWcursor" "true"
 EndSection


### PR DESCRIPTION
The topic-tdk* based platforms did not allow xorg to change resolution at
runtime. Switching from fbdev to modesetting allows xorg to interface with KMS.