### PR TITLE
ttpzu9: update device tree for production testing

### DIFF
--- a/recipes-bsp/device-tree/files/ttpzu9.dts
+++ b/recipes-bsp/device-tree/files/ttpzu9.dts
@@ -207,6 +207,27 @@
 	};
 };
 
+&si5345 {
+	out@0 {
+		always-on;
+	};
+	out@1 {
+		always-on;
+	};
+	out@4 {
+		always-on;
+	};
+	out@6 {
+		always-on;
+	};
+	out@7 {
+		always-on;
+	};
+	out@9 {
+		always-on;
+	};
+};
+
 &usb0 {
 	status = "okay";
 	/* see: https://forums.xilinx.com/t5/Embedded-Linux/Zynqmp-USB2-0/td-p/790522/page/2 */
@@ -214,6 +235,10 @@
 	/delete-property/ clock-names;
 	clocks = <&zynqmp_clk USB0_BUS_REF>;
 	clock-names = "bus_clk";
+};
+
+&uart1 {
+	status = "disabled";
 };
 
 &dwc3_0 {

--- a/recipes-kernel/linux/linux-xlnx/0001-miamiplusmp-update-board-model-correct-qspi-size.patch
+++ b/recipes-kernel/linux/linux-xlnx/0001-miamiplusmp-update-board-model-correct-qspi-size.patch
@@ -1,0 +1,87 @@
+From 045ffa7921b9a071d2a6f07190d8bcccc442af96 Mon Sep 17 00:00:00 2001
+From: Leon Leijssen <leon.leijssen@topic.nl>
+Date: Mon, 18 May 2020 13:53:06 +0200
+Subject: [PATCH] miamiplusmp: update board model & correct qspi size
+
+---
+ .../boot/dts/xilinx/zynqmp-topic-miamiplusmp.dts     | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/xilinx/zynqmp-topic-miamiplusmp.dts b/arch/arm64/boot/dts/xilinx/zynqmp-topic-miamiplusmp.dts
+index 5ff77c05b541..08eb3aabb37d 100644
+--- a/arch/arm64/boot/dts/xilinx/zynqmp-topic-miamiplusmp.dts
++++ b/arch/arm64/boot/dts/xilinx/zynqmp-topic-miamiplusmp.dts
+@@ -21,7 +21,7 @@
+ #include <dt-bindings/phy/phy.h>
+ 
+ / {
+-	model = "Topic Miami MPSoC";
++	model = "Topic Miami Plus MPSoC";
+ 	compatible = "topic,miamiplusmp", "xlnx,zynqmp";
+ 
+ 	aliases {
+@@ -187,12 +187,14 @@
+ 					<100000000>;
+ 
+ 		out@0 {
++			/* MGT_D_REFCLK_0 */
+ 			reg = <0>;
+ 			silabs,format = <1>; /* LVDS 3v3 */
+ 			silabs,common-mode = <3>;
+ 			silabs,amplitude = <3>;
+ 		};
+ 		out@1 {
++			/* MGT_D_REFCLK_2 */
+ 			reg = <1>;
+ 			silabs,format = <1>; /* LVDS 3v3 */
+ 			silabs,common-mode = <3>;
+@@ -215,6 +217,7 @@
+ 			always-on;
+ 		};
+ 		out@4 {
++			/* MGT_D_REFCLK_6 */
+ 			reg = <4>;
+ 			silabs,format = <1>; /* LVDS 3v3 */
+ 			silabs,common-mode = <3>;
+@@ -229,6 +232,7 @@
+ 			always-on;
+ 		};
+ 		out@6 {
++			/* MGT_D_REFCLK_4 */
+ 			reg = <6>;
+ 			silabs,format = <1>; /* LVDS 3v3 */
+ 			silabs,common-mode = <3>;
+@@ -236,6 +240,7 @@
+ 		};
+ 
+ 		out@7 {
++			/* CLOCK_FPGA0 */
+ 			reg = <7>;
+ 			silabs,format = <1>; /* LVDS 1v8 */
+ 			silabs,common-mode = <13>;
+@@ -252,6 +257,7 @@
+ 		};
+ 
+ 		out@9 {
++			/* CLOCK_FPGA1 */
+ 			reg = <9>;
+ 			silabs,format = <1>; /* LVDS 1v8 */
+ 			silabs,common-mode = <13>;
+@@ -286,12 +292,12 @@
+ 		};
+ 		partition@qspi-rootfs {
+ 			label = "qspi-rootfs";
+-			reg = <0x180000 0x7e80000>;
++			reg = <0x180000 0xFE80000>;
+ 		};
+ 		/* Everything */
+ 		partition@qspi-all {
+ 			label = "qspi-all";
+-			reg = <0x0 0x8000000>;
++			reg = <0x0 0x10000000>;
+ 		};
+ 	};
+ };
+-- 
+2.17.1
+

--- a/recipes-kernel/linux/topic-xilinx-kernel-patches.inc
+++ b/recipes-kernel/linux/topic-xilinx-kernel-patches.inc
@@ -56,6 +56,7 @@ SRC_URI_append = "\
 	file://0032-xlnx_pl_disp-fix-missing-xlnx_crtc_unregister.patch \
 	file://0001-clk-clk-si5341-Add-support-for-the-Si5345-series.patch \
 	file://0001-net-mdio_device-Reset-GPIO-is-allowed-to-sleep.patch \
+	file://0001-miamiplusmp-update-board-model-correct-qspi-size.patch \
 	"
 
 # Compile overlay-capable devicetrees


### PR DESCRIPTION
Enable all SI5345 clocks, disable uart1 and correct the QSPI size